### PR TITLE
Add methods to access DV's hash listeners

### DIFF
--- a/public/javascripts/DV/controllers/api.js
+++ b/public/javascripts/DV/controllers/api.js
@@ -256,6 +256,7 @@ DV.Api.prototype = {
   
   // Clobber DV's existing history hooks
   clearHashListeners : function() {
+    this.viewer.history.defaultCallback = null;
     this.viewer.history.handlers = [];
   },
 


### PR DESCRIPTION
A few new methods for the DV API, mostly dealing with manipulating hashChange callbacks:

`clearHashListeners` clobbers the existing DocViewer listeners. It also gets rid of `defaultCallback` which, by default, sends you to the first page of the document if you change the hash to anything DV doesn't recognize.

`registerHashListener` lets you attach your own history handlers to DV.

Unrelated, `getState` is a shortcut to the current state of the doc viewer. 
