### PR TITLE
fullscreen button should open new window with current state

### DIFF
--- a/public/javascripts/DV/helpers/helpers.js
+++ b/public/javascripts/DV/helpers/helpers.js
@@ -299,8 +299,8 @@ DV.Schema.helpers = {
     openFullScreen : function() {
       var doc = this.viewer.schema.document;
       var url = doc.canonicalURL.replace(/#\S+$/,"");
-      var currentPage = this.models.document.currentPage()
-      
+      var currentPage = this.models.document.currentPage();
+
       // construct url fragment based on current viewer state
       switch (this.viewer.state) {
         case 'ViewAnnotation':


### PR DESCRIPTION
by sticking a hash anchor on the end of the URL that represents the current state of the viewer.
