### PR TITLE
CSS class for the pixelping img tag

### DIFF
--- a/public/javascripts/DV/controllers/document_viewer.js
+++ b/public/javascripts/DV/controllers/document_viewer.js
@@ -103,7 +103,7 @@ DV.DocumentViewer.prototype.recordHit = function(hitUrl) {
   url = url.replace(/[\/]+$/, '');
   var id   = parseInt(this.api.getId(), 10);
   var key  = encodeURIComponent('document:' + id + ':' + url);
-  DV.jQuery(document.body).append('<img class="pixelping" alt="" width="1" height="1" src="' + hitUrl + '?key=' + key + '" />');
+  DV.jQuery(document.body).append('<img class="DV-pixelping" alt="" width="1" height="1" src="' + hitUrl + '?key=' + key + '" />');
 };
 
 // jQuery object, scoped to this viewer's container.


### PR DESCRIPTION
Allows for users who embed a document to style around bugs with how the pixel image interacts with their base template.
