### PR TITLE
[issue-8] Fix zoom and page when container is initially hidden

### DIFF
--- a/public/javascripts/DV/controllers/document_viewer.js
+++ b/public/javascripts/DV/controllers/document_viewer.js
@@ -26,6 +26,7 @@ DV.DocumentViewer = function(options) {
   this.dragReporter       = null;
   this.compiled           = {};
   this.tracker            = {};
+  this.visible            = true;
 
   this.onStateChangeCallbacks = [];
 
@@ -133,6 +134,7 @@ DV.load = function(documentRep, options) {
     viewer.loadModels();
     DV.jQuery(function() {
       viewer.open('InitialLoad');
+      viewer.visible = DV.jQuery(viewer.options.container).is(':visible');
       if (options.afterLoad) options.afterLoad(viewer);
       if (DV.afterLoad) DV.afterLoad(viewer);
       if (DV.recordHit) viewer.recordHit(DV.recordHit);

--- a/public/javascripts/DV/events/events.js
+++ b/public/javascripts/DV/events/events.js
@@ -2,6 +2,7 @@
 DV.Schema.events = {
   // Change zoom level and causes a reflow and redraw of pages.
   zoom: function(level){
+    if (!this.viewer.visible) return;
     var viewer = this.viewer;
     var continuation = function() {
       viewer.pageSet.zoom({ zoomLevel: level });
@@ -15,7 +16,7 @@ DV.Schema.events = {
 
   // Draw (or redraw) the visible pages on the screen.
   drawPages: function() {
-    if (this.viewer.state != 'ViewDocument') return;
+    if (this.viewer.state != 'ViewDocument' || !this.viewer.visible) return;
     var doc           = this.models.document;
     var win           = this.elements.window[0];
     var offsets       = doc.baseHeightsPortionOffsets;
@@ -43,6 +44,14 @@ DV.Schema.events = {
     if (last) pages.pop();
     pages[first ? 0 : pages.length - 1].currentPage = true;
     this.viewer.pageSet.draw(pages);
+  },
+
+  checkVisibility: function() {
+    if (this.elements.viewer.is(':visible') && !this.viewer.visible) {
+      this.viewer.visible = true;
+      this.viewer.events.drawPages();
+      this.viewer.helpers.autoZoomPage();
+    }
   },
 
   check: function(){

--- a/public/javascripts/DV/states/states.js
+++ b/public/javascripts/DV/states/states.js
@@ -28,6 +28,7 @@ DV.Schema.states = {
 
     this.helpers.positionViewer();
     this.models.document.computeOffsets();
+    this.helpers.addObserver('checkVisibility');
     this.helpers.addObserver('drawPages');
     this.helpers.registerHashChangeEvents();
     this.dragReporter = new DV.DragReporter(this, '.DV-pageCollection',DV.jQuery.proxy(this.helpers.shift, this), { ignoreSelector: '.DV-annotationContent' });

--- a/viewer-embed-debug.html
+++ b/viewer-embed-debug.html
@@ -123,5 +123,21 @@
   });
 </script>
 
+<div id="doc5" style="margin: 30px; float: left; display: none;">
+</div>
+
+<script type="text/javascript">
+  var docUrl = 'http://www.documentcloud.org/documents/837007-defence-costings-for-special-purpose-aircraft.js';
+  DV.load(docUrl, {
+    container: '#doc5',
+    width: 650,
+    height: 500,
+    sidebar: false
+  });
+  setTimeout(function() {
+    document.getElementById('doc5').style.display = 'block';
+  }, 5000);
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
Fixes #8

Adds a control for when the container is initially visible, as the zoom and page calculations do not work properly in that case. Added a case to the viewer-embed-debug.html to ensure that the fix works.
