### PR TITLE
Fix for issue #59

### DIFF
--- a/public/javascripts/DV/helpers/search.js
+++ b/public/javascripts/DV/helpers/search.js
@@ -122,6 +122,7 @@ DV._.extend(DV.Schema.helpers, {
         }
       }
       toHighLight = false;
+      this.viewer.toHighLight = null;
     }
     var searchResponse = this.viewer.searchResponse;
     if (searchResponse) {
@@ -130,7 +131,7 @@ DV._.extend(DV.Schema.helpers, {
         if(searchResponse.results.length === currentPageIndex+1){
           return;
         }
-        toHighLight = 'first';
+        
         this.events.loadText(searchResponse.results[currentPageIndex + 1] - 1,this.highlightSearchResponses);
 
         return;
@@ -138,8 +139,8 @@ DV._.extend(DV.Schema.helpers, {
         if(currentPageIndex-1 < 0){
           return  false;
         }
-        toHighLight = 'last';
-        this.events.loadText(searchResponse.results[currentPageIndex - 1] - 1,this.highlightSearchResponses);
+        this.viewer.toHighLight = 'last';
+        this.events.loadText(String(searchResponse.results[currentPageIndex - 1] - 1),this.highlightSearchResponses);
 
         return;
       }


### PR DESCRIPTION
Fixed Transition from Page 2 to Page 1 when clicking on Previous Match. Also now, when the first match of a concrete page is highlighted, clicking on previous match will highlight the last match of the previous page (if exists) instead of the first one
